### PR TITLE
chore: Output complete file path

### DIFF
--- a/packages/astro-fuse/src/index.ts
+++ b/packages/astro-fuse/src/index.ts
@@ -102,8 +102,9 @@ export default function astroFuse(_config?: AstroFuseConfig): AstroIntegration {
 
       'astro:build:done': (opts) => {
         if (_basedOn === 'source') {
-          if (existsSync(join(outDir, OUTFILE))) {
-            log(`\`${OUTFILE}\` is created.`)
+          const fuseJson = join(outDir, OUTFILE)
+          if (existsSync(fuseJson)) {
+            log(`\`${fuseJson}\` is created.`)
           }
 
           return


### PR DESCRIPTION
I was using `basedOn: 'output'` and noticed pretty late that the resulting file was located in `dist/fuse.json`. That's why I propose to output the whole file path.

The official [@astrojs/sitemap](https://docs.astro.build/en/guides/integrations-guide/sitemap/) plugin for example outputs the following:

> @astrojs/sitemap: `sitemap-index.xml` created at `dist`

So it seems to be a good practice to also mention the output directory.